### PR TITLE
Scale argment updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,7 @@ Imports:
     purrr,
     rlang,
     stats,
-    tibble,
-    tidyselect
+    tibble
 Suggests: 
     covr,
     dplyr,

--- a/R/checks.R
+++ b/R/checks.R
@@ -50,7 +50,7 @@ check_value_order <- function(low, high, target = NULL) {
   invisible(NULL)
 }
 
-check_vectors <- function(values, d) {
+is_vector_args <- function(values, d) {
   if (!is.vector(values) || !is.numeric(values)) {
     rlang::abort("'values' should be a numeric vector.")
   }
@@ -89,3 +89,14 @@ check_scale <- function(x) {
 
   invisible(NULL)
 }
+
+is_d_input <- function(x) {
+  tmp <- purrr::map(x, check_numeric, input = "desirability")
+  tmp <- purrr::map(x, check_unit_range)
+  size <- purrr::map_int(x, length)
+  if (length(unique(size)) != 1) {
+    rlang::abort("All desirability inputs should have the same length.")
+  }
+  invisible(TRUE)
+}
+

--- a/R/checks.R
+++ b/R/checks.R
@@ -47,7 +47,7 @@ check_value_order <- function(low, high, target = NULL) {
       rlang::abort("The values should be `low < high`.")
     }
   }
-  invisible(TRUE)
+  invisible(NULL)
 }
 
 check_vectors <- function(values, d) {
@@ -79,3 +79,13 @@ check_args <- function(arg, x, use_data, fn, type = "low") {
   arg
 }
 
+check_scale <- function(x) {
+  if (length(x) != 1 || !is.numeric(x) || is.na(x)) {
+    rlang::abort("The scale parameter should be a single numeric value.")
+  }
+  if (x <= 0) {
+    rlang::abort("The scale parameter great then zero.")
+  }
+
+  invisible(NULL)
+}

--- a/R/computations.R
+++ b/R/computations.R
@@ -46,7 +46,7 @@
   check_unit_range(missing)
   check_unit_range(d)
   check_numeric(x)
-  check_vectors(values, d)
+  is_vector_args(values, d)
 
   ord <- order(values)
   values <- values[ord]

--- a/R/in-line.R
+++ b/R/in-line.R
@@ -14,7 +14,11 @@
 #' @param low,high,target Single numeric values that define the active ranges of
 #' desirability.
 #' @param scale,scale_low,scale_high A single numeric value to rescale the
-#' desirability function.
+#' desirability function (each should be great than 0.0). Values >1.0 make the
+#' desirability more difficult to satisfy while smaller values make it easier
+#' (see the examples below). `scale_low` and  `scale_high` do the same for
+#' target functions with `scale_low` affecting the range below the `target`
+#' value and `scale_high` affecting values greater than `target`.
 #' @param missing A single numeric value on `[0, 1]` (or `NA_real_`) that
 #' defines how missing values in `x` are mapped to the desirability score.
 #' @param use_data Should the low, middle, and/or high values be derived from
@@ -27,12 +31,52 @@
 #' included in `categories` are given the value in `missing`.
 #' @return A numeric vector on `[0, 1]` where larger values are more
 #' desirable.
+#' @details
+#' Each function translates the values to desirability on `[0, 1]`.
+#'
+#' ## Equations
+#'
+#' ### Maximization
+#'
+#' - `data > high`: d = 1.0
+#' - `data < low`: d = 0.0
+#' - `low <= data <= high`: \eqn{d = \left(\frac{data-low}{high-low}\right)^{scale}}
+#'
+#' ### Minimization
+#'
+#' - `data > high`: d = 0.0
+#' - `data < low`: d = 1.0
+#' - `low <= data <= high`: \eqn{d = \left(\frac{data = low}{low - high}\right)^{scale}}
+#'
+#' ### Target
+#'
+#' - `data > high`: d = 0.0
+#' - `data < low`: d = 0.0
+#' - `low <= data <= target`: \eqn{d = \left(\frac{data - low}{target - low}\right)^{scale\_low}}
+#' - `target <= data <= high`: \eqn{d = \left(\frac{data - high}{target - high}\right)^{scale\_high}}
+#'
+#' ### Minimization
+#'
+#' - `data > high`: d = 0.0
+#' - `data < low`: d = 0.0
+#' - `low <= data <= high`:d = 1.0
+#'
+#' ### Categories
+#' - `data = level`: d = 1.0
+#' - `data != level`: d = 0.0
+#'
+#' ### Custom
+#'
+#' For the sequence of values given to the function, `d_custom()` will return
+#' the desirability values that correspond to data matching values in `x_vals`.
+#' Otherwise, linear interpolation is used for values in-between.
+#'
 #' @seealso [d_overall()]
 #' @references Derringer, G. and Suich, R. (1980), Simultaneous Optimization of
 #' Several Response Variables. _Journal of Quality Technology_, 12, 214-219.
 #' @export
 #' @name inline_desirability
-#' @examples
+#' @examplesIf rlang::is_installed(c("dplyr", "ggplot2"))
 #' library(dplyr)
 #' library(ggplot2)
 #'

--- a/R/in-line.R
+++ b/R/in-line.R
@@ -166,6 +166,7 @@
 d_max <- function(x, low, high, scale = 1, missing = NA_real_, use_data = FALSE) {
   low  <- check_args(low,  x, use_data, fn = "d_max")
   high <- check_args(high, x, use_data, fn = "d_max", type = "high")
+  check_scale(scale)
 
   .comp_max(x, low, high, scale, missing)
 }
@@ -175,6 +176,8 @@ d_max <- function(x, low, high, scale = 1, missing = NA_real_, use_data = FALSE)
 d_min <- function(x, low, high, scale = 1, missing = NA_real_, use_data = FALSE) {
   low  <- check_args(low,  x, use_data, fn = "d_min")
   high <- check_args(high, x, use_data, fn = "d_min", type = "high")
+  check_scale(scale)
+
   .comp_min(x, low, high, scale, missing)
 }
 
@@ -186,6 +189,8 @@ d_target <- function(x, low, target, high, scale_low = 1, scale_high = 1,
   low    <- check_args(low,    x, use_data, fn = "d_target")
   high   <- check_args(high,   x, use_data, fn = "d_target", type = "high")
   target <- check_args(target, x, use_data, fn = "d_target", type = "target")
+  check_scale(scale_low)
+  check_scale(scale_high)
 
   .comp_target(x, low, target, high, scale_low, scale_high, missing)
 }

--- a/R/overall.R
+++ b/R/overall.R
@@ -42,7 +42,7 @@ d_overall <- function(..., geometric = TRUE, tolerance = 0) {
   d_lst <- list(...)
   d_lst <- maybe_name(d_lst)
   vals <- dplyr::bind_cols(d_lst)
-  check_d_inputs(vals)
+  is_d_input(vals)
   if (ncol(vals) == 1) {
     return(vals[[1]])
   }
@@ -85,12 +85,3 @@ geomean <- function(x, na.rm = TRUE) {
   exp(sum(log(x), na.rm = na.rm) / sum(!is.na(x)))
 }
 
-check_d_inputs <- function(x) {
-  tmp <- purrr::map(x, check_numeric, input = "desirability")
-  tmp <- purrr::map(x, check_unit_range)
-  size <- purrr::map_int(x, length)
-  if (length(unique(size)) != 1) {
-    rlang::abort("All desirability inputs should have the same length.")
-  }
-  invisible(TRUE)
-}

--- a/R/overall.R
+++ b/R/overall.R
@@ -14,7 +14,7 @@
 #' @return A numeric vector.
 #' @seealso [d_max()]
 #' @export
-#' @examples
+#' @examplesIf rlang::is_installed("dplyr")
 #' library(dplyr)
 #'
 #' # Choose model tuning parameters that minimize the number of predictors used

--- a/man/d_overall.Rd
+++ b/man/d_overall.Rd
@@ -26,6 +26,7 @@ Once desirability columns have been created, determine the overall
 desirability using a mean (geometric by default).
 }
 \examples{
+\dontshow{if (rlang::is_installed("dplyr")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(dplyr)
 
 # Choose model tuning parameters that minimize the number of predictors used
@@ -48,6 +49,7 @@ classification_results \%>\%
     d_all  = d_overall(across(starts_with("d_")))
   ) \%>\%
   arrange(desc(d_all))
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=d_max]{d_max()}}

--- a/man/inline_desirability.Rd
+++ b/man/inline_desirability.Rd
@@ -38,7 +38,11 @@ d_category(x, categories, missing = NA_real_)
 desirability.}
 
 \item{scale, scale_low, scale_high}{A single numeric value to rescale the
-desirability function.}
+desirability function (each should be great than 0.0). Values >1.0 make the
+desirability more difficult to satisfy while smaller values make it easier
+(see the examples below). \code{scale_low} and  \code{scale_high} do the same for
+target functions with \code{scale_low} affecting the range below the \code{target}
+value and \code{scale_high} affecting values greater than \code{target}.}
 
 \item{missing}{A single numeric value on \verb{[0, 1]} (or \code{NA_real_}) that
 defines how missing values in \code{x} are mapped to the desirability score.}
@@ -67,7 +71,58 @@ does the opposite. See the plots in the examples to see more examples.
 Currently, only the desirability functions defined by Derringer and Suich
 (1980) are implemented.
 }
+\details{
+Each function translates the values to desirability on \verb{[0, 1]}.
+\subsection{Equations}{
+\subsection{Maximization}{
+\itemize{
+\item \code{data > high}: d = 1.0
+\item \code{data < low}: d = 0.0
+\item \verb{low <= data <= high}: \eqn{d = \left(\frac{data-low}{high-low}\right)^{scale}}
+}
+}
+
+\subsection{Minimization}{
+\itemize{
+\item \code{data > high}: d = 0.0
+\item \code{data < low}: d = 1.0
+\item \verb{low <= data <= high}: \eqn{d = \left(\frac{data = low}{low - high}\right)^{scale}}
+}
+}
+
+\subsection{Target}{
+\itemize{
+\item \code{data > high}: d = 0.0
+\item \code{data < low}: d = 0.0
+\item \verb{low <= data <= target}: \eqn{d = \left(\frac{data - low}{target - low}\right)^{scale\_low}}
+\item \verb{target <= data <= high}: \eqn{d = \left(\frac{data - high}{target - high}\right)^{scale\_high}}
+}
+}
+
+\subsection{Minimization}{
+\itemize{
+\item \code{data > high}: d = 0.0
+\item \code{data < low}: d = 0.0
+\item \verb{low <= data <= high}:d = 1.0
+}
+}
+
+\subsection{Categories}{
+\itemize{
+\item \code{data = level}: d = 1.0
+\item \code{data != level}: d = 0.0
+}
+}
+
+\subsection{Custom}{
+
+For some function \eqn(f()), desirability is \eqn(f(data)).
+}
+
+}
+}
 \examples{
+\dontshow{if (rlang::is_installed(c("dplyr", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(dplyr)
 library(ggplot2)
 
@@ -153,7 +208,7 @@ tibble(x = letters[1:7]) \%>\%
 
 dat \%>\%
   mutate(across(c(everything()), ~ d_min(., .2, .6), .names = "d_{col}"))
-
+\dontshow{\}) # examplesIf}
 }
 \references{
 Derringer, G. and Suich, R. (1980), Simultaneous Optimization of

--- a/man/inline_desirability.Rd
+++ b/man/inline_desirability.Rd
@@ -116,7 +116,9 @@ Each function translates the values to desirability on \verb{[0, 1]}.
 
 \subsection{Custom}{
 
-For some function \eqn(f()), desirability is \eqn(f(data)).
+For the sequence of values given to the function, \code{d_custom()} will return
+the desirability values that correspond to data matching values in \code{x_vals}.
+Otherwise, linear interpolation is used for values in-between.
 }
 
 }

--- a/tests/testthat/_snaps/in-line.md
+++ b/tests/testthat/_snaps/in-line.md
@@ -1,0 +1,173 @@
+# correct values
+
+    The values should be `low < high`.
+
+---
+
+    'low' should be a single numeric value.
+
+---
+
+    'high' should be a single numeric value.
+
+---
+
+    'low' should be a single numeric value.
+
+---
+
+    'high' should be a single numeric value.
+
+---
+
+    The scale parameter great then zero.
+
+---
+
+    The scale parameter should be a single numeric value.
+
+---
+
+    The scale parameter should be a single numeric value.
+
+---
+
+    The scale parameter great then zero.
+
+---
+
+    The values should be `low < high`.
+
+---
+
+    'low' should be a single numeric value.
+
+---
+
+    'high' should be a single numeric value.
+
+---
+
+    'low' should be a single numeric value.
+
+---
+
+    'high' should be a single numeric value.
+
+---
+
+    The scale parameter great then zero.
+
+---
+
+    The scale parameter should be a single numeric value.
+
+---
+
+    The scale parameter should be a single numeric value.
+
+---
+
+    The scale parameter great then zero.
+
+---
+
+    'low' should be a single numeric value.
+
+---
+
+    'target' should be a single numeric value.
+
+---
+
+    'high' should be a single numeric value.
+
+---
+
+    'low' should be a single numeric value.
+
+---
+
+    'target' should be a single numeric value.
+
+---
+
+    'high' should be a single numeric value.
+
+---
+
+    The scale parameter great then zero.
+
+---
+
+    The scale parameter should be a single numeric value.
+
+---
+
+    The scale parameter should be a single numeric value.
+
+---
+
+    The scale parameter great then zero.
+
+---
+
+    The scale parameter great then zero.
+
+---
+
+    The scale parameter should be a single numeric value.
+
+---
+
+    The scale parameter should be a single numeric value.
+
+---
+
+    The scale parameter great then zero.
+
+---
+
+    'values' and 'd' should be the same length.
+
+---
+
+    'values' and 'd' should be the same length.
+
+---
+
+    'values' should be a numeric vector.
+
+---
+
+    Desirability values should be numeric and complete in the range [0, 1].
+
+---
+
+    The values should be `low < high`.
+
+---
+
+    'low' should be a single numeric value.
+
+---
+
+    'high' should be a single numeric value.
+
+---
+
+    'low' should be a single numeric value.
+
+---
+
+    'high' should be a single numeric value.
+
+---
+
+    i In argument: `d_all = d_overall(across(everything()))`.
+    Caused by error in `purrr::map()`:
+    i In index: 6.
+    i With name: num_features.
+    Caused by error in `.f()`:
+    ! Desirability values should be numeric and complete in the range [0, 1].
+

--- a/tests/testthat/test-in-line.R
+++ b/tests/testthat/test-in-line.R
@@ -41,26 +41,16 @@ test_that('correct values', {
     c(0, 0, 0.002, 0.0156, 0.0527, 0.125, 0.2441, 0.4219, 0.6699, 1, 1),
     tolerance = 0.1
   )
-  expect_error(
-    d_max(x, 0, -1),
-    "The values should be `low < high`"
-  )
-  expect_error(
-    d_max(x, 0:1, 2),
-    "low' should be a single numeric value"
-  )
-  expect_error(
-    d_max(x, 0, 1:2),
-    "high' should be a single numeric value"
-  )
-  expect_error(
-    d_max(x, NA_real_, 1:2),
-    "low' should be a single numeric value"
-  )
-  expect_error(
-    d_max(x, 0, NA_real_),
-    "high' should be a single numeric value"
-  )
+  expect_snapshot_error(d_max(x, 0, -1))
+  expect_snapshot_error(d_max(x, 0:1, 2))
+  expect_snapshot_error(d_max(x, 0, 1:2))
+  expect_snapshot_error(d_max(x, NA_real_, 1:2))
+  expect_snapshot_error(d_max(x, 0, NA_real_))
+  expect_snapshot_error(d_max(x, 0, 1, scale = -1))
+  expect_snapshot_error(d_max(x, 0, 1, scale = 1:2))
+  expect_snapshot_error(d_max(x, 0, 1, scale = NA))
+  expect_snapshot_error(d_max(x, 0, 1, scale = 0))
+
   # ------------------------------------------------------------------------------
 
   expect_equal(
@@ -81,26 +71,15 @@ test_that('correct values', {
     c(1, 1, 0.6699, 0.4219, 0.2441, 0.125, 0.0527, 0.0156, 0.002, 0, 0),
     tolerance = 0.1
   )
-  expect_error(
-    d_min(x, 0, -1),
-    "The values should be `low < high`"
-  )
-  expect_error(
-    d_min(x, 0:1, 2),
-    "low' should be a single numeric value"
-  )
-  expect_error(
-    d_min(x, 0, 1:2),
-    "high' should be a single numeric value"
-  )
-  expect_error(
-    d_min(x, NA_real_, 1:2),
-    "low' should be a single numeric value"
-  )
-  expect_error(
-    d_min(x, 0, NA_real_),
-    "high' should be a single numeric value"
-  )
+  expect_snapshot_error(d_min(x, 0, -1))
+  expect_snapshot_error(d_min(x, 0:1, 2))
+  expect_snapshot_error(d_min(x, 0, 1:2))
+  expect_snapshot_error(d_min(x, NA_real_, 1:2))
+  expect_snapshot_error(d_min(x, 0, NA_real_))
+  expect_snapshot_error(d_min(x, .1, .9, scale = -1))
+  expect_snapshot_error(d_min(x, .1, .9, scale = 1:2))
+  expect_snapshot_error(d_min(x, .1, .9, scale = NA))
+  expect_snapshot_error(d_min(x, .1, .9, scale = 0))
 
   # ------------------------------------------------------------------------------
 
@@ -114,30 +93,21 @@ test_that('correct values', {
     c(0, 0, 0.7071, 1, 0.5787, 0.2963, 0.125, 0.037, 0.0046, 0, 0),
     tolerance = 0.1
   )
-  expect_error(
-    d_target(x, 0:1, 2, 3),
-    "low' should be a single numeric value"
-  )
-  expect_error(
-    d_target(x, 0, 1:2, 3),
-    "target' should be a single numeric value"
-  )
-  expect_error(
-    d_target(x, 0, 1, 2:3),
-    "high' should be a single numeric value"
-  )
-  expect_error(
-    d_target(x, NA_real_, 1, 2),
-    "low' should be a single numeric value"
-  )
-  expect_error(
-    d_target(x, 0, NA_real_, 1),
-    "target' should be a single numeric value"
-  )
-  expect_error(
-    d_target(x, 0, 1, NA_real_),
-    "high' should be a single numeric value"
-  )
+  expect_snapshot_error(d_target(x, 0:1, 2, 3))
+  expect_snapshot_error(d_target(x, 0, 1:2, 3))
+  expect_snapshot_error(d_target(x, 0, 1, 2:3))
+  expect_snapshot_error(d_target(x, NA_real_, 1, 2))
+  expect_snapshot_error(d_target(x, 0, NA_real_, 1))
+  expect_snapshot_error(d_target(x, 0, 1, NA_real_))
+  expect_snapshot_error(d_target(x, .1, .3, .9, scale_low = -1))
+  expect_snapshot_error(d_target(x, .1, .3, .9, scale_low = 1:2))
+  expect_snapshot_error(d_target(x, .1, .3, .9, scale_low = NA))
+  expect_snapshot_error(d_target(x, .1, .3, .9, scale_low = 0))
+  expect_snapshot_error(d_target(x, .1, .3, .9, scale_high = -1))
+  expect_snapshot_error(d_target(x, .1, .3, .9, scale_high = 1:2))
+  expect_snapshot_error(d_target(x, .1, .3, .9, scale_high = NA))
+  expect_snapshot_error(d_target(x, .1, .3, .9, scale_high = 0))
+
   # ------------------------------------------------------------------------------
 
   x_points <- (1:5)/5
@@ -147,22 +117,10 @@ test_that('correct values', {
     c(0, 0, 0.36, 0.5, 0.64, 0.74, 0.84, 0.9, 0.96, 0.98, 1),
     tolerance = 0.1
   )
-  expect_error(
-    d_custom(x, x_points[-1], d_points),
-    "'values' and 'd' should be the same length"
-  )
-  expect_error(
-    d_custom(x, x_points, d_points[-1]),
-    "'values' and 'd' should be the same length"
-  )
-  expect_error(
-    d_custom(x, letters, d_points),
-    "'values' should be a numeric vector"
-  )
-  expect_error(
-    d_custom(x, x_points, letters),
-    "Desirability values should be numeric and complete"
-  )
+  expect_snapshot_error(d_custom(x, x_points[-1], d_points))
+  expect_snapshot_error(d_custom(x, x_points, d_points[-1]))
+  expect_snapshot_error(d_custom(x, letters, d_points))
+  expect_snapshot_error(d_custom(x, x_points, letters))
 
   # ------------------------------------------------------------------------------
 
@@ -171,26 +129,12 @@ test_that('correct values', {
     c(0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0),
     tolerance = 0.1
   )
-  expect_error(
-    d_box(x, 0, -1),
-    "The values should be `low < high`"
-  )
-  expect_error(
-    d_box(x, 0:1, 2),
-    "low' should be a single numeric value"
-  )
-  expect_error(
-    d_box(x, 0, 1:2),
-    "high' should be a single numeric value"
-  )
-  expect_error(
-    d_box(x, NA_real_, 1:2),
-    "low' should be a single numeric value"
-  )
-  expect_error(
-    d_box(x, 0, NA_real_),
-    "high' should be a single numeric value"
-  )
+  expect_snapshot_error(d_box(x, 0, -1))
+  expect_snapshot_error(d_box(x, 0:1, 2))
+  expect_snapshot_error(d_box(x, 0, 1:2))
+  expect_snapshot_error(d_box(x, NA_real_, 1:2))
+  expect_snapshot_error(d_box(x, 0, NA_real_))
+
   # ------------------------------------------------------------------------------
 
   lvls <- (1:5)/5
@@ -210,9 +154,8 @@ test_that('correct values', {
     res %>% mutate(d_all  = d_overall(d_feat, d_roc)) %>% purrr::pluck("d_all"),
     sqrt(res$d_feat * res$d_roc)
   )
-  expect_error(
-    res %>% mutate(d_all  = d_overall(across(everything()))),
-    "Desirability values should be numeric and complete in the range"
+  expect_snapshot_error(
+    res %>% mutate(d_all  = d_overall(across(everything())))
   )
 
 


### PR DESCRIPTION
Closes #3 

Closes #4 

Closes #2

A few notes: 

 - converted all error-based tests to snapshots
 - removed the unused tidyselect dependency
 - all examples use `@examplesIf rlang::is_installed(blah blah)`
