### PR TITLE
Minor doc fixes

### DIFF
--- a/R/in-line.R
+++ b/R/in-line.R
@@ -26,7 +26,7 @@
 #' @param x_vals,desirability Numeric vectors of the same length that define the
 #' desirability results at specific values of `x`. Values below and above the
 #' data in `x_vals` are given values of zero and one, respectively.
-#' @param categories A named list of desirability values that match all
+#' @param categories A named vector of desirability values that match all
 #' possible categories to specific desirability values. Data that are not
 #' included in `categories` are given the value in `missing`.
 #' @return A numeric vector on `[0, 1]` where larger values are more
@@ -55,11 +55,11 @@
 #' - `low <= data <= target`: \eqn{d = \left(\frac{data - low}{target - low}\right)^{scale\_low}}
 #' - `target <= data <= high`: \eqn{d = \left(\frac{data - high}{target - high}\right)^{scale\_high}}
 #'
-#' ### Minimization
+#' ### Box
 #'
 #' - `data > high`: d = 0.0
 #' - `data < low`: d = 0.0
-#' - `low <= data <= high`:d = 1.0
+#' - `low <= data <= high`: d = 1.0
 #'
 #' ### Categories
 #' - `data = level`: d = 1.0

--- a/man/inline_desirability.Rd
+++ b/man/inline_desirability.Rd
@@ -54,7 +54,7 @@ the data (\code{x}) using the minimum, maximum, or median (respectively)?}
 desirability results at specific values of \code{x}. Values below and above the
 data in \code{x_vals} are given values of zero and one, respectively.}
 
-\item{categories}{A named list of desirability values that match all
+\item{categories}{A named vector of desirability values that match all
 possible categories to specific desirability values. Data that are not
 included in \code{categories} are given the value in \code{missing}.}
 }
@@ -99,11 +99,11 @@ Each function translates the values to desirability on \verb{[0, 1]}.
 }
 }
 
-\subsection{Minimization}{
+\subsection{Box}{
 \itemize{
 \item \code{data > high}: d = 0.0
 \item \code{data < low}: d = 0.0
-\item \verb{low <= data <= high}:d = 1.0
+\item \verb{low <= data <= high}: d = 1.0
 }
 }
 


### PR DESCRIPTION
Hi @topepo,

Just a few minor fixes I noticed when playing around with this package. Hope it is helpful.

For the `list` -> `vector` change, it turns out `categories` can't be a `list` because it fails `check_unit_range()`, specifically:
https://github.com/tidymodels/desirability2/blob/564fc8a3244b34e54a2dbb6dc494c14a55fc8aa7/R/checks.R#L17