### PR TITLE
updates for no-suggests checks

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -1,0 +1,59 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check-hard.yaml
+
+permissions: read-all
+
+jobs:
+  check-no-suggests:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ URL: https://desirability2.tidymodels.org,
 Depends: 
     R (>= 2.10)
 Imports: 
+    dplyr,
     glue,
     purrr,
     rlang,
@@ -22,7 +23,6 @@ Imports:
     tibble
 Suggests: 
     covr,
-    dplyr,
     ggplot2,
     spelling,
     testthat (>= 3.0.0)


### PR DESCRIPTION
Add a GH workflow that only directly installs "hard" dependencies, i.e. Depends, Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never installed, with the exception of testthat, knitr, and rmarkdown. The cache is never used to avoid accidentally restoring a cache containing a suggested dependency.